### PR TITLE
Fix Queen Royal Game link name

### DIFF
--- a/portfolio/projects.html
+++ b/portfolio/projects.html
@@ -48,9 +48,9 @@
             </article>
             <hr>
             <article>
-              <h3>Queen-Royal-Game-forked-</h3>
+              <h3>Queen-Royal-Game-forked</h3>
               <p>A game where you navigate Wikipedia articles through links to find Queen Elizabeth II, starting from a random set of articles.</p>
-              <p><a href="https://github.com/damienneimad/Queen-Royal-Game-forked-">View on GitHub</a></p>
+              <p><a href="https://github.com/damienneimad/Queen-Royal-Game-forked">View on GitHub</a></p>
               <p><a href="https://codesandbox.io/p/github/damienneimad/Queen%20Royal%20Game%20(forked)">Live Demo</a></p>
             </article>
             

--- a/portfolio/projects_data.json
+++ b/portfolio/projects_data.json
@@ -21,8 +21,8 @@
         "notes": "Description updated from README."
     },
     {
-        "name": "Queen-Royal-Game-forked-",
-        "url": "https://github.com/damienneimad/Queen-Royal-Game-forked-",
+        "name": "Queen-Royal-Game-forked",
+        "url": "https://github.com/damienneimad/Queen-Royal-Game-forked",
         "description": "A game where you navigate Wikipedia articles through links to find Queen Elizabeth II, starting from a random set of articles.",
         "homepage": "https://codesandbox.io/p/github/damienneimad/Queen%20Royal%20Game%20(forked)",
         "notes": "Description updated from README."

--- a/projects.html
+++ b/projects.html
@@ -48,9 +48,9 @@
             </article>
             <hr>
             <article>
-              <h3>Queen-Royal-Game-forked-</h3>
+              <h3>Queen-Royal-Game-forked</h3>
               <p>A game where you navigate Wikipedia articles through links to find Queen Elizabeth II, starting from a random set of articles.</p>
-              <p><a href="https://github.com/damienneimad/Queen-Royal-Game-forked-">View on GitHub</a></p>
+              <p><a href="https://github.com/damienneimad/Queen-Royal-Game-forked">View on GitHub</a></p>
               <p><a href="https://codesandbox.io/p/github/damienneimad/Queen%20Royal%20Game%20(forked)">Live Demo</a></p>
             </article>
             

--- a/projects_data.json
+++ b/projects_data.json
@@ -21,8 +21,8 @@
         "notes": "Description updated from README."
     },
     {
-        "name": "Queen-Royal-Game-forked-",
-        "url": "https://github.com/damienneimad/Queen-Royal-Game-forked-",
+        "name": "Queen-Royal-Game-forked",
+        "url": "https://github.com/damienneimad/Queen-Royal-Game-forked",
         "description": "A game where you navigate Wikipedia articles through links to find Queen Elizabeth II, starting from a random set of articles.",
         "homepage": "https://codesandbox.io/p/github/damienneimad/Queen%20Royal%20Game%20(forked)",
         "notes": "Description updated from README."


### PR DESCRIPTION
## Summary
- fix Queen Royal Game heading and GitHub link text
- update project data names for the forked repo

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f6ae814d48327b906f8955af8669a